### PR TITLE
Switch to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
     - name: Setup Build ID
       run: |
         [[ "$MATRIX_OS" == ubuntu* ]] && osName=linux || osName="${MATRIX_OS:0:3}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:


### PR DESCRIPTION
As of v3, the gradle/gradle-build-action action has been superseded by gradle/gradle-build-action v3 (which has its first non-rc release a couple of days ago).